### PR TITLE
Consolidate cells, use colab forms

### DIFF
--- a/text2im.ipynb
+++ b/text2im.ipynb
@@ -139,26 +139,6 @@
     {
       "cell_type": "markdown",
       "source": [
-        "### Input **your** text prompt"
-      ],
-      "metadata": {
-        "id": "b7AYtgbxO4sG"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "prompt = \"an oil painting of a corgi\""
-      ],
-      "metadata": {
-        "id": "jWDlp7teQFVb"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
         "### Sample at 64x64 resolution"
       ],
       "metadata": {
@@ -169,27 +149,22 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "wTIvLDaRNOHB"
+        "id": "0vL5aXMgNOHF",
+        "cellView": "form"
       },
       "outputs": [],
       "source": [
+        "#@title Sample from the base model\n",
+        "prompt = \"an oil painting of a corgi\"  #@param {type:\"string\"}\n",
+        "\n",
         "# Sampling parameters\n",
-        "batch_size = 1\n",
-        "guidance_scale = 3.0\n",
+        "batch_size =  1#@param {type:\"integer\"}\n",
+        "guidance_scale = 3.0 #@param {type:\"number\"}\n",
         "\n",
         "# Tune this parameter to control the sharpness of 256x256 images.\n",
         "# A value of 1.0 is sharper, but sometimes results in grainy artifacts.\n",
-        "upsample_temp = 0.997"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "0vL5aXMgNOHF"
-      },
-      "outputs": [],
-      "source": [
+        "upsample_temp = 0.997 #@param {type:\"number\"}\n",
+        "\n",
         "##############################\n",
         "# Sample from the base model #\n",
         "##############################\n",
@@ -240,28 +215,10 @@
         "    model_kwargs=model_kwargs,\n",
         "    cond_fn=None,\n",
         ")[:batch_size]\n",
-        "model.del_cache()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Show the output"
-      ],
-      "metadata": {
-        "id": "e38KxGgeP-vR"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
+        "model.del_cache()\n",
+        "\n",
         "show_images(samples)"
-      ],
-      "metadata": {
-        "id": "yJ98jwv_P-K5"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -276,10 +233,12 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "FdFBhsSYNOHH"
+        "id": "FdFBhsSYNOHH",
+        "cellView": "form"
       },
       "outputs": [],
       "source": [
+        "#@title Upsample the 64x64 samples\n",
         "##############################\n",
         "# Upsample the 64x64 samples #\n",
         "##############################\n",
@@ -318,28 +277,11 @@
         "    model_kwargs=model_kwargs,\n",
         "    cond_fn=None,\n",
         ")[:batch_size]\n",
-        "model_up.del_cache()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Show the output"
-      ],
-      "metadata": {
-        "id": "rSz87eX0QbM4"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
+        "model_up.del_cache()\n",
+        "\n",
+        "\n",
         "show_images(up_samples)"
-      ],
-      "metadata": {
-        "id": "vUI3HJ5hQZFT"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     }
   ],
   "metadata": {


### PR DESCRIPTION
Consolidate cells, use colab forms for parameter input.

The resulting notebook looks cleaner:
<img width="600" alt="Screen Shot 2021-12-21 at 11 31 20 AM" src="https://user-images.githubusercontent.com/2865203/146987851-6840f22c-b724-4b2f-8579-f6e673da3384.png">

With this change, to try another prompt only two cells need to be run: 64x64 sample and 256x256 upsample.